### PR TITLE
[FEATURE] Copy commit message command to clipboard

### DIFF
--- a/data/messages.txt
+++ b/data/messages.txt
@@ -30,4 +30,5 @@ Update packages
 What could possibly go wrong
 Works like a charm
 [WIP]
+[object Object]
 ¯\_(ツ)_/¯

--- a/public/assets/javascript/copy.js
+++ b/public/assets/javascript/copy.js
@@ -1,0 +1,12 @@
+const commitCmd = document.querySelector("code.typing").innerHTML.trim();
+const copyBtn = document.querySelector(".clipboardBtn");
+
+copyBtn.addEventListener("click", () => {
+  navigator.clipboard.writeText(commitCmd)
+    .then(() => {
+      console.log("✅");
+    })
+    .catch((error) => {
+      console.error("Error copying text to clipboard:", error);
+    });
+});

--- a/public/assets/style/custom.css
+++ b/public/assets/style/custom.css
@@ -21,6 +21,11 @@ code.typing {
 code.typing::before {
     content: '$ ';
 }
+
+.clipboardBtn:hover {
+    cursor: pointer;
+}
+
 @font-face {
     font-family: "JetBrains Mono", monospace;
     src: url("../fonts/jbm-reg.woff2") format("woff2");

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,13 +12,6 @@
         <link rel="stylesheet" href="{{ asset('assets/style/pico.min.css') }}">
         <link rel="stylesheet" href="{{ asset('assets/style/custom.css') }}">
         <title>{% block title %}Git Yolo!{% endblock %}</title>
-        {% block stylesheets %}
-            {{ encore_entry_link_tags('app') }}
-        {% endblock %}
-
-        {% block javascripts %}
-            {{ encore_entry_script_tags('app') }}
-        {% endblock %}
     </head>
     <body>
 
@@ -33,6 +26,6 @@
                 {% include 'partials/footer.html.twig' with { routes } %}
             {% endif %}
         #}
-
+        <script src="{{ asset('assets/javascript/copy.js') }}"></script>
     </body>
 </html>

--- a/templates/homepage.html.twig
+++ b/templates/homepage.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig'%}
 
 {% block body %}
-    <section class="shell-wrapper">
+    <section class="shell-wrapper clipboardBtn">
         <pre>
             <code class="typing">
                 git commit -m "{{ message }}"


### PR DESCRIPTION
This PR extends the UI to allow users to copy the commit message to their local clipboards if supported by their browser. 