### PR TITLE
[BUGFIX] Work around mocking MessageRepository

### DIFF
--- a/phpunit.coverage.xml
+++ b/phpunit.coverage.xml
@@ -22,6 +22,7 @@
         <report>
             <clover outputFile=".build/coverage/clover.xml" />
             <text outputFile="php://stdout" showUncoveredFiles="true"/>
+            <html outputDirectory=".build/coverage/html" />
         </report>
     </coverage>
     <logging>

--- a/src/Enum/MessageSource.php
+++ b/src/Enum/MessageSource.php
@@ -23,8 +23,9 @@ namespace App\Enum;
 
 enum MessageSource: string
 {
-    case Mixed = 'mixed';
     case LocalFile = '/data/messages.txt';
+    case Mixed = '';
+    case TestCaseWorkAround = 'foo'; // I'm still trying to figure out a better way to kinda mock enum values
     case Undefined = '¯\_(ツ)_/¯';
     case WhatTheCommit = 'https://raw.githubusercontent.com/ngerakines/commitment/main/commit_messages.txt';
 }

--- a/src/Repository/MessageRepository.php
+++ b/src/Repository/MessageRepository.php
@@ -35,7 +35,7 @@ final class MessageRepository
             return match ($source) {
                 MessageSource::Mixed => $this->getRandomMessageFromVariousSources(),
                 MessageSource::LocalFile => $this->getRandomMessageFromFile(
-                    $this->getPathToLocalFile(MessageSource::LocalFile->value),
+                    $this->getPathToLocalFile($source->value),
                 ),
                 MessageSource::WhatTheCommit => $this->getRandomMessageFromFile(
                     $source->value,
@@ -43,11 +43,9 @@ final class MessageRepository
                 ),
                 default => MessageSource::Undefined->value,
             };
-            // @codeCoverageIgnoreStart
-        } catch (CouldNotReadFromFileException $e) {
+        } catch (CouldNotReadFromFileException) {
             return MessageSource::Undefined->value;
         }
-        // @codeCoverageIgnoreEnd
     }
 
     public function getPathToLocalFile(string $relativePath): string
@@ -62,7 +60,8 @@ final class MessageRepository
      */
     public function getMessageArrayFromFile(string $filePath): array
     {
-        $fileContents = file_get_contents($filePath);
+        /** @phpstan-ignore-next-line */
+        $fileContents = @file_get_contents($filePath);
 
         if (false === $fileContents) {
             throw CouldNotReadFromFileException::create($filePath);

--- a/src/Repository/MessageRepository.php
+++ b/src/Repository/MessageRepository.php
@@ -34,7 +34,8 @@ final class MessageRepository
         try {
             return match ($source) {
                 MessageSource::Mixed => $this->getRandomMessageFromVariousSources(),
-                MessageSource::LocalFile => $this->getRandomMessageFromFile(
+                MessageSource::LocalFile,
+                MessageSource::TestCaseWorkAround => $this->getRandomMessageFromFile(
                     $this->getPathToLocalFile($source->value),
                 ),
                 MessageSource::WhatTheCommit => $this->getRandomMessageFromFile(

--- a/tests/Controller/MessageControllerTest.php
+++ b/tests/Controller/MessageControllerTest.php
@@ -57,10 +57,6 @@ final class MessageControllerTest extends WebTestCase
         /** @phpstan-ignore-next-line */
         $mockRepo = $this->createMock(MessageRepository::class);
         $mockRepo
-            ->method('getRandomMessageFromFile')
-            ->willThrowException(new CouldNotReadFromFileException());
-
-        $mockRepo
             ->method('getRandomMessageBySource')
             ->willReturn(MessageSource::Undefined->value);
 

--- a/tests/Repository/MessageRepositoryTest.php
+++ b/tests/Repository/MessageRepositoryTest.php
@@ -22,6 +22,7 @@
 namespace App\Tests\Repository;
 
 use App\Enum\MessageSource;
+use App\Exception\CouldNotReadFromFileException;
 use App\Repository\MessageRepository;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -58,11 +59,20 @@ final class MessageRepositoryTest extends TestCase
         self::assertNotEmpty($localMessage);
     }
 
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    #[Test]
+    public function getRandomMessageFromSourceWillReturnDefaultAfterExceptionIsCaught(): void
+    {
+        /** @/phpstan-ignore-next-line */
+        self::assertEquals(MessageSource::Undefined->value, $this->messageRepository->getRandomMessageBySource(MessageSource::LocalFile));
+    }
+
     #[Test]
     public function getRandomMessageFromFileWillThrowException(): void
     {
         self::expectException(\App\Exception\CouldNotReadFromFileException::class);
-
         $this->messageRepository->getRandomMessageFromFile('dummy.txt');
     }
 }

--- a/tests/Repository/MessageRepositoryTest.php
+++ b/tests/Repository/MessageRepositoryTest.php
@@ -22,7 +22,6 @@
 namespace App\Tests\Repository;
 
 use App\Enum\MessageSource;
-use App\Exception\CouldNotReadFromFileException;
 use App\Repository\MessageRepository;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -59,14 +58,10 @@ final class MessageRepositoryTest extends TestCase
         self::assertNotEmpty($localMessage);
     }
 
-    /**
-     * @throws \PHPUnit\Framework\MockObject\Exception
-     */
     #[Test]
     public function getRandomMessageFromSourceWillReturnDefaultAfterExceptionIsCaught(): void
     {
-        /** @/phpstan-ignore-next-line */
-        self::assertEquals(MessageSource::Undefined->value, $this->messageRepository->getRandomMessageBySource(MessageSource::LocalFile));
+        self::assertEquals(MessageSource::Undefined->value, $this->messageRepository->getRandomMessageBySource(MessageSource::TestCaseWorkAround));
     }
 
     #[Test]


### PR DESCRIPTION
OK. Hear me out. 

This far from ideal. And honestly I hate to see an Enum case just for unit test and more so for the code coverage. But it somehow trumps `@codeCoverageIgnore` today. 🤷 